### PR TITLE
移除对 h1-h6 标签的特别处理和增加对数学公式 \tag 的特别支持

### DIFF
--- a/main.py
+++ b/main.py
@@ -341,7 +341,7 @@ if __name__ == "__main__":
     # url = "https://zhuanlan.zhihu.com/p/614627181"
 
     # 专栏
-    url = "https://zhuanlan.zhihu.com/p/24770526"
+    url = "https://www.zhihu.com/column/c_1704981555632713730"
 
     # hexo_uploader=True 表示在公式前后加上 {% raw %} {% endraw %}，以便 hexo 正确解析
     judge_zhihu_type(url, hexo_uploader=False)

--- a/main.py
+++ b/main.py
@@ -111,13 +111,6 @@ def save_and_transform(title_element, content_element, author, url, hexo_uploade
         for img_lazy in content_element.find_all("img", class_=lambda x: 'lazy' in x if x else True):
             img_lazy.decompose()
 
-        # 处理内容中的标题
-        for header in content_element.find_all(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']):
-            header_level = int(header.name[1])  # 从标签名中获取标题级别（例如，'h2' -> 2）
-            header_text = header.get_text(strip=True)  # 提取标题文本
-            markdown_header = f"{'#' * header_level} {header_text}"  # 转换为 Markdown 格式的标题
-            header.replace_with(markdown_header)
-
         # 处理回答中的图片
         for img in content_element.find_all("img"):
             # 将图片链接替换为本地路径
@@ -348,7 +341,7 @@ if __name__ == "__main__":
     # url = "https://zhuanlan.zhihu.com/p/614627181"
 
     # 专栏
-    url = "https://www.zhihu.com/column/c_1704981555632713730"
+    url = "https://zhuanlan.zhihu.com/p/24770526"
 
     # hexo_uploader=True 表示在公式前后加上 {% raw %} {% endraw %}，以便 hexo 正确解析
     judge_zhihu_type(url, hexo_uploader=False)

--- a/main.py
+++ b/main.py
@@ -173,11 +173,17 @@ def save_and_transform(title_element, content_element, author, url, hexo_uploade
 
         # 提取并存储数学公式
         math_formulas = []
+        math_tags = []
         for math_span in content_element.select("span.ztext-math"):
             latex_formula = math_span['data-tex']
-            math_formulas.append(latex_formula)
+            
             # 使用特殊标记标记位置
-            math_span.replace_with("@@MATH@@")
+            if latex_formula.find("\\tag") != -1:
+                math_tags.append(latex_formula)
+                math_span.replace_with("@@MATH_FORMULA@@")
+            else:
+                math_formulas.append(latex_formula)
+                math_span.replace_with("@@MATH@@")
 
         # 获取文本内容
         content = content_element.decode_contents().strip()
@@ -195,6 +201,20 @@ def save_and_transform(title_element, content_element, author, url, hexo_uploade
                     content = content.replace("@@MATH@@", f"{formula}", 1)
                 else:
                     content = content.replace("@@MATH@@", f"${formula}$", 1)
+        
+        for formula in math_tags:
+            if hexo_uploader:
+                content = content.replace(
+                    "@@MATH\_FORMULA@@",
+                    "$$" + "{% raw %}" + formula + "{% endraw %}" + "$$",
+                    1,
+                )
+            else:
+                # 如果公式中包含 $ 则不再添加 $ 符号
+                if formula.find("$") != -1:
+                    content = content.replace("@@MATH\_FORMULA@@", f"{formula}", 1)
+                else:
+                    content = content.replace("@@MATH\_FORMULA@@", f"$${formula}$$", 1)
 
     else:
         content = ""


### PR DESCRIPTION
对于测试链接：https://zhuanlan.zhihu.com/p/24770526 。
导出时出现标题和内容连结情况，具体情况如下图：

![image](https://github.com/chenluda/zhihu-download/assets/79794883/8d90ecb5-7b98-455d-a2c3-78051aada7e4)

---

既然使用了 `markdownify` 库来处理 `markdown` 内容，个人觉得没有必要在此多此一举。