### PR TITLE
修正了一下专栏不能下载的问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -451,7 +451,7 @@ def parse_zhihu_column(url, session, hexo_uploader):
 
     while True:
         api_url = f"/api/v4/columns/{url.split('/')[-1]}/items?limit=10&offset={offset}"
-        response = requests.get(f"https://www.zhihu.com{api_url}")
+        response = session.get(f"https://www.zhihu.com{api_url}")
         data = response.json()
 
         for item in data["data"]:


### PR DESCRIPTION
在拉取文章列表的时候 会检查cookies
否则第二个offset拉取的会是空页面
 
键入加入sleep时间 以防止过快的访问频率被ban掉