### PR TITLE
chore(tampermonkey.js)：移除公式首尾空白符以解决导出markdown在部分编辑器下的未渲染问题

### DIFF
--- a/tampermonkey.js
+++ b/tampermonkey.js
@@ -100,7 +100,7 @@
                        node.hasAttribute('data-tex');
             },
             replacement: (content, node) => {
-                const formula = node.getAttribute('data-tex');
+                const formula = node.getAttribute('data-tex').trim();
                 if (formula.includes('\\tag')) {
                     return `\n$$${formula}$$\n`;
                 } else {


### PR DESCRIPTION
发现知乎公式首尾有空格，在我的编辑器obsidian下会未渲染，修改脚本以trim首尾空格
来源：
<img width="2442" height="540" alt="image" src="https://github.com/user-attachments/assets/4a6f4def-67b0-44e9-871e-7b42a341de8a" />
在我的obsidian上未渲染表现：
<img width="1206" height="315" alt="image" src="https://github.com/user-attachments/assets/2ae9b378-8ab7-4b0e-8980-4201153219a3" />
